### PR TITLE
need to make it support more pages in maimai net

### DIFF
--- a/mai-search.js
+++ b/mai-search.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         mai-search
-// @version      3
+// @version      3.2
 // @description  quick search maimai songs in youtube
 // @author       tomtom
 // @match        https://maimaidx-eng.com/maimai-mobile/record/*
@@ -16,9 +16,9 @@
 
     var styleElement = document.createElement("style");
     var str = `
-div[class="basic_block m_5 p_5 p_l_10 f_13 break"]::before,
-td[class="scoreRecordCell songTitleCell"]::before,
-div[class="music_name_block t_l f_13 break"]::before {
+div.basic_block.m_5.p_5.p_l_10.f_13.break::before,
+td.scoreRecordCell.songTitleCell::before,
+div.w_250.f_l.t_l::after {
   content: '';
   display: inline-block;
   height: 15px;
@@ -31,6 +31,15 @@ div[class="music_name_block t_l f_13 break"]::before {
   background-size: contain;
   background-repeat: no-repeat;
   touch-action: manipulation;
+}
+
+div.w_250.f_l.t_l::after {
+    content: 'Click the level to mai-search';
+    width: 100%;
+    padding-left: 20px;
+    cursor: default;
+    margin-top: 20px;
+    box-sizing: border-box;
 }
 `;
     var cssRules = document.createTextNode(str);
@@ -47,13 +56,12 @@ div[class="music_name_block t_l f_13 break"]::before {
             return true;
         }
         button.setAttribute('yt', 'true');
-        console.log(button);
         return false;
     }
 
     // For https://myjian.github.io/mai-tools/rating-calculator/*
     function addEvent_stalk() {
-        var buttons = document.querySelectorAll('td[class="scoreRecordCell songTitleCell"]');
+        var buttons = document.querySelectorAll('td.scoreRecordCell.songTitleCell');
         buttons.forEach(function(button) {
             if (!haveListener(button)) {
                 button.addEventListener('click', function() {
@@ -65,9 +73,9 @@ div[class="music_name_block t_l f_13 break"]::before {
         });
     }
 
-    // For https://maimaidx-eng.com/maimai-mobile/record/*
+    // For https://maimaidx-eng.com/maimai-mobile/record/* , exclude /musicDetail/*
     function addEvent_record() {
-        var buttons = document.querySelectorAll('div[class="basic_block m_5 p_5 p_l_10 f_13 break"]');
+        var buttons = document.querySelectorAll('div.basic_block.m_5.p_5.p_l_10.f_13.break');
         buttons.forEach(function(button) {
             if (!haveListener(button)) {
                 button.addEventListener('click', function() {
@@ -81,12 +89,27 @@ div[class="music_name_block t_l f_13 break"]::before {
         });
     }
 
-    function addEvent_score() {
-        var buttons = document.querySelectorAll('div[class="music_name_block t_l f_13 break"]');
-        buttons.forEach(function(button) {
+    // For https://maimaidx-eng.com/maimai-mobile/record/musicDetail/*
+    function addEvent_detail() {
+        var children = document.querySelectorAll('td.f_0 div.music_lv_back.m_3.t_c.f_14');
+        children.forEach(function(child) {
+            var button = child.parentNode;
+            console.log("test");
             if (!haveListener(button)) {
+                console.log(button);
+                button.style.cursor = "pointer !important";
                 button.addEventListener('click', function() {
-                    // some code
+                    var title = document.querySelector('div.m_5.f_15.break').textContent;
+                    var value = button.parentElement.querySelector('input[name="diff"]').value;
+                    var diff;
+                    switch(value) {
+                        case '0': {diff = "basic"; break;}
+                        case '1': {diff = "advanced"; break;}
+                        case '2': {diff = "expert"; break;}
+                        case '3': {diff = "master"; break;}
+                        case '4': {diff = "re:master"; break;}
+                        default: diff = '';
+                    };
                     searchYT(title, diff);
                 });
             }
@@ -95,9 +118,9 @@ div[class="music_name_block t_l f_13 break"]::before {
 
     // main
     var observer;
-    if (url.match("maimaidx-eng.com/maimai-mobile/record/musicMybest") ||
-    url.match("maimaidx-eng.com/maimai-mobile/record/musicGenre")) {
-        // making
+    if (url.match("maimaidx-eng.com/maimai-mobile/record/musicDetail")) {
+        addEvent_detail();
+        observer = new MutationObserver(addEvent_detail);
     } else if (url.match("maimaidx-eng.com/maimai-mobile/record")){
         addEvent_record();
         observer = new MutationObserver(addEvent_record);

--- a/mai-search.js
+++ b/mai-search.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         mai-search
-// @version      2.3
+// @version      3
 // @description  quick search maimai songs in youtube
 // @author       tomtom
 // @match        https://maimaidx-eng.com/maimai-mobile/record/*
@@ -12,9 +12,13 @@
 (function() {
     'use strict';
 
+    const url = window.location.href;
+
     var styleElement = document.createElement("style");
     var str = `
-div[class="basic_block m_5 p_5 p_l_10 f_13 break"]::before, td[class="scoreRecordCell songTitleCell"]::before {
+div[class="basic_block m_5 p_5 p_l_10 f_13 break"]::before,
+td[class="scoreRecordCell songTitleCell"]::before,
+div[class="music_name_block t_l f_13 break"]::before {
   content: '';
   display: inline-block;
   height: 15px;
@@ -33,12 +37,6 @@ div[class="basic_block m_5 p_5 p_l_10 f_13 break"]::before, td[class="scoreRecor
     styleElement.appendChild(cssRules);
     document.head.appendChild(styleElement);
 
-
-    function removeLV (str) {
-        var arr = str.split(' ');
-        return str.replace('Lv ' + arr[arr.length-1], '');
-    }
-
     function searchYT (title, diff) {
         var url = 'https://www.youtube.com/results?search_query=maimai+' + title + ' ' + diff;
         window.open(url.replace(' ', '+'), "_blank");
@@ -53,7 +51,8 @@ div[class="basic_block m_5 p_5 p_l_10 f_13 break"]::before, td[class="scoreRecor
         return false;
     }
 
-    function addEvent() {
+    // For https://myjian.github.io/mai-tools/rating-calculator/*
+    function addEvent_stalk() {
         var buttons = document.querySelectorAll('td[class="scoreRecordCell songTitleCell"]');
         buttons.forEach(function(button) {
             if (!haveListener(button)) {
@@ -66,21 +65,46 @@ div[class="basic_block m_5 p_5 p_l_10 f_13 break"]::before, td[class="scoreRecor
         });
     }
 
-    var buttons = document.querySelectorAll('div[class="basic_block m_5 p_5 p_l_10 f_13 break"]');
-    buttons.forEach(function(button) {
-        if (!haveListener(button)) {
-            button.addEventListener('click', function() {
-                var title = removeLV(button.textContent);
-                var diff = button.parentElement.className.slice(8,-10);
-                searchYT(title, diff);
-            });
-        }
-    });
+    // For https://maimaidx-eng.com/maimai-mobile/record/*
+    function addEvent_record() {
+        var buttons = document.querySelectorAll('div[class="basic_block m_5 p_5 p_l_10 f_13 break"]');
+        buttons.forEach(function(button) {
+            if (!haveListener(button)) {
+                button.addEventListener('click', function() {
+                    var str = button.textContent;
+                    var arr = str.split(' ');
+                    var title = str.replace('Lv ' + arr[arr.length-1], '');
+                    var diff = button.parentElement.className.slice(8,-10);
+                    searchYT(title, diff);
+                });
+            }
+        });
+    }
 
-    var observer = new MutationObserver(() => {
-        addEvent();
-    });
+    function addEvent_score() {
+        var buttons = document.querySelectorAll('div[class="music_name_block t_l f_13 break"]');
+        buttons.forEach(function(button) {
+            if (!haveListener(button)) {
+                button.addEventListener('click', function() {
+                    // some code
+                    searchYT(title, diff);
+                });
+            }
+        });
+    }
+
+    // main
+    var observer;
+    if (url.match("maimaidx-eng.com/maimai-mobile/record/musicMybest") ||
+    url.match("maimaidx-eng.com/maimai-mobile/record/musicGenre")) {
+        // making
+    } else if (url.match("maimaidx-eng.com/maimai-mobile/record")){
+        addEvent_record();
+        observer = new MutationObserver(addEvent_record);
+    } else if (url.match("myjian.github.io/mai-tools/rating-calculator")) {
+        addEvent_stalk();
+        observer = new MutationObserver(addEvent_stalk);
+    }
     observer.observe(document.body, {childList: true , subtree: true});
-    addEvent();
 
 })();


### PR DESCRIPTION
There are many song titles in maimai net. In some page, the mai-search is not supported.
For example:
- https://maimaidx-eng.com/maimai-mobile/record/musicGenre/
- https://maimaidx-eng.com/maimai-mobile/record/musicMybest/
In those pages, the song titles are buttons that will direct you to the details of the song.
The 'click' event listener(mai-search) will override the button, and it is not good :(
<hr>

solution 1: change the mai-search button into a seperate div instead of using ::before
solution 2: use different stuff to replace the mai search button